### PR TITLE
Make lazyloading optional

### DIFF
--- a/canonicalwebteam/image_template/__init__.py
+++ b/canonicalwebteam/image_template/__init__.py
@@ -48,6 +48,13 @@ def image_template(url, alt, width, height, hi_def, **attributes):
         extra_classes = attributes["extra_classes"]
         del attributes["extra_classes"]
 
+    # Add lazy load class by default
+    lazy = True
+
+    if "lazy" in attributes:
+        lazy = attributes["lazy"]
+        del attributes["lazy"]
+
     return template.render(
         url=url,
         alt=alt,
@@ -56,6 +63,7 @@ def image_template(url, alt, width, height, hi_def, **attributes):
         width=int(width),
         height=int(height),
         hi_def=hi_def,
+        lazy=lazy,
         extra_classes=extra_classes,
         attributes=attributes,
     )

--- a/canonicalwebteam/templates/image_template.html
+++ b/canonicalwebteam/templates/image_template.html
@@ -1,12 +1,12 @@
 <img
   {% if hi_def %}
-   data-srcset="https://res.cloudinary.com/canonical/image/fetch/{{ hi_def_cloudinary_options }}/{{ url }} 2x"
+   {% if lazy %}data-{% endif %}srcset="https://res.cloudinary.com/canonical/image/fetch/{{ hi_def_cloudinary_options }}/{{ url }} 2x"
   {% endif %}
-  data-src="https://res.cloudinary.com/canonical/image/fetch/{{ std_def_cloudinary_options }}/{{ url }}"
+  {% if lazy %}data-{% endif %}src="https://res.cloudinary.com/canonical/image/fetch/{{ std_def_cloudinary_options }}/{{ url }}"
   alt="{{ alt }}"
   width="{{ width }}"
   height="{{ height }}"
-  class="lazyload{% if extra_classes %} {{ extra_classes }}{% endif %}"
+  class="{% if lazy %}lazyload{% endif %} {% if extra_classes %}{{ extra_classes }}{% endif %}"
   {% for attr_name, attr_value in attributes.items() %}
     {{ attr_name }}="{{ attr_value }}"
   {% endfor %}

--- a/tests/test_image_template.py
+++ b/tests/test_image_template.py
@@ -55,6 +55,19 @@ class TestImageTemplate(unittest.TestCase):
         # Check lazyload class still exists
         self.assertTrue(markup.find('class="lazyload test-title"') > -1)
 
+    def test_optional_lazy(self):
+        markup = image_template(
+            url=asset_url,
+            alt="test",
+            width="1920",
+            height="1080",
+            extra_classes="test-title",
+            hi_def=False,
+            lazy=False,
+        )
+        # Check lazyload class is not present
+        self.assertTrue(markup.find('class="test-title"') > -1)
+
     def test_hi_def(self):
         markup = image_template(
             url=non_asset_url,

--- a/tests/test_image_template.py
+++ b/tests/test_image_template.py
@@ -38,8 +38,8 @@ class TestImageTemplate(unittest.TestCase):
             title="test title",
             hi_def=False,
         )
-        self.assertTrue(markup.find('id="test"') > -1)
-        self.assertTrue(markup.find('title="test title"') > -1)
+        self.assertIn('id="test"', markup)
+        self.assertIn('title="test title"', markup)
 
     def test_classes(self):
         markup = image_template(
@@ -51,9 +51,10 @@ class TestImageTemplate(unittest.TestCase):
             hi_def=False,
         )
         # Check custom class exists
-        self.assertTrue(markup.find('class="test-title"') > -1)
+        self.assertIn('class="test-title"', markup)
+
         # Check lazyload class still exists
-        self.assertTrue(markup.find('class="lazyload test-title"') > -1)
+        self.assertIn('class="lazyload test-title"', markup)
 
     def test_optional_lazy(self):
         markup = image_template(
@@ -66,7 +67,7 @@ class TestImageTemplate(unittest.TestCase):
             lazy=False,
         )
         # Check lazyload class is not present
-        self.assertTrue(markup.find('class="test-title"') > -1)
+        self.assertIn('class="test-title"', markup)
 
     def test_hi_def(self):
         markup = image_template(


### PR DESCRIPTION
## Done

To counter the visible delay it takes for lazy loading to occur, adding this option will allow users to take advantage of `srcset` without JS enabled lazy loading. 

This option can then be used on images "above the fold" 

## QA

- Sanity check code
- Verify tests pass

