### PR TITLE
Add fill option

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,1 +1,2 @@
+v1.1.0, 2020-04-28: Add `fill`.
 v1.0.0, 2019-10-09: Native `loading` support; nicer lazysizes markup; Added `attrs` dictionary.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ will:
 - `width` (mandatory integer): The number of pixels wide the image should be
 - `height` (mandatory integer): The number of pixels high the image should be
 - `hi_def` (mandatory boolean): Has an image been uploaded 2x the width and height of the desired size
+- `fill` (optional boolean): Set the crop mode to ["fill"](https://cloudinary.com/documentation/image_transformation_reference#crop_parameter)
 - `loading` (optional string, default: "lazy"): Set to ["auto" or "eager"](https://addyosmani.com/blog/lazy-loading/) to disable lazyloading
 - `attrs` (optional dictionary): Extra `<img>` attributes (e.g. `class` or `id`) can be passed as additional arguments
 
@@ -37,6 +38,7 @@ image_markup = image_template(
     height="319",
     hi_def=True,
     loading="auto",
+	fill=True,
     attrs={"class": "hero", "id": "openstack-hero"},
 )
 ```
@@ -84,7 +86,7 @@ Use it in templates:
 ``` html
 # templates/mytemplate.html
 
-{% image url="https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png" alt="Operational dashboard" width="1040" height="585" hi_def=True %}
+{% image url="https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png" alt="Operational dashboard" width="1040" height="585" hi_def=True fill=True %}
 ```
 
 ### Flask usage
@@ -116,6 +118,7 @@ Use it in templates, e.g.::
     width="534",
     height="319",
     hi_def=True,
+	fill=True,
     loading="auto",
     attrs={"class": "hero", "id": "openstack-hero"},
   ) | safe
@@ -128,8 +131,8 @@ The output image markup will be e.g.:
 
 ``` html
 <img
-    src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_534,h_319/https://assets.ubuntu.com/v1/450d7c2f-openstack-hero.svg"
-    srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_1068,h_638/https://assets.ubuntu.com/v1/450d7c2f-openstack-hero.svg 2x"
+    src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_534,h_319,c_fill/https://assets.ubuntu.com/v1/450d7c2f-openstack-hero.svg"
+    srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_1068,h_638,c_fill/https://assets.ubuntu.com/v1/450d7c2f-openstack-hero.svg 2x"
     alt=""
     width="534"
     height="319"

--- a/canonicalwebteam/image_template/__init__.py
+++ b/canonicalwebteam/image_template/__init__.py
@@ -11,7 +11,9 @@ env = Environment(loader=FileSystemLoader(parent_dir + "/templates"))
 template = env.get_template("image_template.html")
 
 
-def image_template(url, alt, width, height, hi_def, loading="lazy", attrs={}):
+def image_template(
+    url, alt, width, height, hi_def, fill=False, loading="lazy", attrs={}
+):
     """
     Generate image markup
     """
@@ -26,6 +28,12 @@ def image_template(url, alt, width, height, hi_def, loading="lazy", attrs={}):
         "q_auto",  # Auto optimise quality
         "fl_sanitize",  # Sanitize SVG content
     ]
+
+    # If the original image does not match the requested
+    # ratio set crop and fill see
+    # https://cloudinary.com/documentation/image_transformation_reference#crop_parameter
+    if fill == True:
+        cloudinary_options.append("c_fill")
 
     if not url_parts.netloc:
         raise Exception("url must contain a hostname")

--- a/canonicalwebteam/image_template/__init__.py
+++ b/canonicalwebteam/image_template/__init__.py
@@ -32,7 +32,7 @@ def image_template(
     # If the original image does not match the requested
     # ratio set crop and fill see
     # https://cloudinary.com/documentation/image_transformation_reference#crop_parameter
-    if fill == True:
+    if fill:
         cloudinary_options.append("c_fill")
 
     if not url_parts.netloc:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="canonicalwebteam.image-template",
-    version="1.0.0",
+    version="1.1.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(

--- a/tests/test_image_template.py
+++ b/tests/test_image_template.py
@@ -65,6 +65,19 @@ class TestImageTemplate(unittest.TestCase):
         # Check lazyload class is not present
         self.assertIn('class="test-title"', markup)
 
+    def test_optional_fill(self):
+        markup = image_template(
+            url=asset_url,
+            alt="test",
+            width="1920",
+            height="1080",
+            loading="auto",
+            fill=True,
+            hi_def=False,
+        )
+        # Check c_fill is present
+        self.assertIn("c_fill", markup)
+
     def test_hi_def(self):
         markup = image_template(
             url=non_asset_url,


### PR DESCRIPTION
Sometimes we don't have control over the original image, but would like to display multiple consistently. The crop-fill parameter allows this flexibility. See https://cloudinary.com/documentation/image_transformation_reference#crop_parameter.

This PR adds an optional parameter to the module.