### PR TITLE
Allow height to be auto

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,2 +1,3 @@
+v1.2.0, 2020-07-24: Allow height "auto"
 v1.1.0, 2020-04-28: Add `fill`.
 v1.0.0, 2019-10-09: Native `loading` support; nicer lazysizes markup; Added `attrs` dictionary.

--- a/canonicalwebteam/image_template/__init__.py
+++ b/canonicalwebteam/image_template/__init__.py
@@ -12,7 +12,14 @@ template = env.get_template("image_template.html")
 
 
 def image_template(
-    url, alt, width, height, hi_def, fill=False, loading="lazy", attrs={}
+    url,
+    alt,
+    width,
+    hi_def,
+    height=None,
+    fill=False,
+    loading="lazy",
+    attrs={},
 ):
     """
     Generate image markup
@@ -42,11 +49,15 @@ def image_template(
     hi_def_cloudinary_options = cloudinary_options.copy()
 
     std_def_cloudinary_options.append("w_" + str(width))
-    std_def_cloudinary_options.append("h_" + str(height))
+
+    if height is not None:
+        std_def_cloudinary_options.append("h_" + str(height))
 
     if hi_def:
         hi_def_cloudinary_options.append("w_" + str(int(width) * 2))
-        hi_def_cloudinary_options.append("h_" + str(int(height) * 2))
+
+        if height is not None:
+            hi_def_cloudinary_options.append("h_" + str(int(height) * 2))
 
     return template.render(
         url=url,
@@ -54,7 +65,7 @@ def image_template(
         std_def_cloudinary_options=",".join(std_def_cloudinary_options),
         hi_def_cloudinary_options=",".join(hi_def_cloudinary_options),
         width=int(width),
-        height=int(height),
+        height=height,
         hi_def=hi_def,
         loading=loading,
         attrs=attrs,

--- a/canonicalwebteam/templates/image_template.html
+++ b/canonicalwebteam/templates/image_template.html
@@ -9,7 +9,9 @@
       {%- endif %}
       alt="{{ alt }}"
       width="{{ width }}"
+      {%- if height is not None %}
       height="{{ height }}"
+      {%- endif %}
       loading="{{ loading }}"
       {%- for attr_name, attr_value in attrs.items() %}
       {{ attr_name }}="{{ attr_value }}"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="canonicalwebteam.image-template",
-    version="1.1.0",
+    version="1.2.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(

--- a/tests/test_image_template.py
+++ b/tests/test_image_template.py
@@ -104,6 +104,18 @@ class TestImageTemplate(unittest.TestCase):
         self.assertTrue(markup_asset.find("x2"))
         self.assertTrue(markup_asset.find("w%3D3840%26h%3D2160"))
 
+    def test_height_is_optional(self):
+        image = image_template(
+            url=non_asset_url,
+            alt="test",
+            width="1920",
+            height="auto",
+            hi_def=True,
+        )
+
+        self.assertIn('height="auto"', image)
+        self.assertNotIn("h_auto", image)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In situations where we do no know the height of an image, we want to allow the value to be "auto" to prevent image distortions.

QA
--
1. Go to your local ubuntu.com repo. Enable the image-template changes for testing:
```bash
git remote add albert-fork git@github.com:albertkol/ubuntu.com.git  # get my fork if you don't have it
git fetch albert-fork  # fetch the branches
git checkout test-image-template-height-auto  # checkout the branch

dotrun  # run website
```

Browse on the local website to `/openstack` look at the top left image:
![image](https://user-images.githubusercontent.com/6387619/88381059-944f3580-cd9d-11ea-8e5d-253ad9588ecc.png)

Open a new brower tab. Go to: https://ubuntu.com/openstack
The image should look exactly the same.

Bonus points:
On the local website: 
If you inspect element the openstack image, you should see the property `height` set to `auto`. 
if you check the `src` of the image you will not find any `h_` setting set to cloudinary.
if you check the `srcset` of the image you will not find any `h_` setting set to cloudinary.

On the production website: 
If you inspect element the openstack image, you should see the property `height` set to `184`.
if you check the `src` of the image you will find the `h_` setting set to `184` to cloudinary.
if you check the `srcset` of the image you will find the `h_` setting set to `368` to cloudinary.