### PR TITLE
Add e_sharpen

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+v1.3.0, 2020-09-24: Add e_sharpen to images
 v1.2.0, 2020-07-24: Make height optional
 v1.1.0, 2020-04-28: Add `fill`.
 v1.0.0, 2019-10-09: Native `loading` support; nicer lazysizes markup; Added `attrs` dictionary.

--- a/canonicalwebteam/image_template/__init__.py
+++ b/canonicalwebteam/image_template/__init__.py
@@ -12,7 +12,14 @@ template = env.get_template("image_template.html")
 
 
 def image_template(
-    url, alt, hi_def, width, height=None, fill=False, loading="lazy", attrs={},
+    url,
+    alt,
+    hi_def,
+    width,
+    height=None,
+    fill=False,
+    loading="lazy",
+    attrs={},
 ):
     """
     Generate image markup

--- a/canonicalwebteam/image_template/__init__.py
+++ b/canonicalwebteam/image_template/__init__.py
@@ -27,6 +27,7 @@ def image_template(
         "f_auto",  # Auto choose format
         "q_auto",  # Auto optimise quality
         "fl_sanitize",  # Sanitize SVG content
+        "e_sharpen",  # Sharpen images
     ]
 
     # If the original image does not match the requested

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="canonicalwebteam.image-template",
-    version="1.2.0",
+    version="1.3.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(

--- a/tests/test_image_template.py
+++ b/tests/test_image_template.py
@@ -119,7 +119,10 @@ class TestImageTemplate(unittest.TestCase):
 
     def test_height_is_optional(self):
         image = image_template(
-            url=non_asset_url, alt="test", width="1920", hi_def=True,
+            url=non_asset_url,
+            alt="test",
+            width="1920",
+            hi_def=True,
         )
 
         self.assertNotIn("height=", image)

--- a/tests/test_image_template.py
+++ b/tests/test_image_template.py
@@ -78,6 +78,19 @@ class TestImageTemplate(unittest.TestCase):
         # Check c_fill is present
         self.assertIn("c_fill", markup)
 
+    def test_e_sharpen(self):
+        markup = image_template(
+            url=asset_url,
+            alt="test",
+            width="1920",
+            height="1080",
+            loading="auto",
+            fill=True,
+            hi_def=False,
+        )
+        # Check e_sharpen is present
+        self.assertIn("e_sharpen", markup)
+
     def test_hi_def(self):
         markup = image_template(
             url=non_asset_url,


### PR DESCRIPTION
Add e_sharpen to images to improve their quality.

## QA
Open in a tab: https://ubuntu.com/blog
Open in a tab: https://ubuntu-com-8353.demos.haus/blog
If you keep switching between the tabs you will see that the demo one has sharper images. Or you can inspect element and see the `e_sharpen` flag on the cloudinary url. 