### PR TITLE
Make e sharpen optional

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+v1.3.1, 2020-09-24: Make e_sharpen optional
 v1.3.0, 2020-09-24: Add e_sharpen to images
 v1.2.0, 2020-07-24: Make height optional
 v1.1.0, 2020-04-28: Add `fill`.

--- a/canonicalwebteam/image_template/__init__.py
+++ b/canonicalwebteam/image_template/__init__.py
@@ -18,6 +18,7 @@ def image_template(
     width,
     height=None,
     fill=False,
+    e_sharpen=False,
     loading="lazy",
     attrs={},
 ):
@@ -34,8 +35,10 @@ def image_template(
         "f_auto",  # Auto choose format
         "q_auto",  # Auto optimise quality
         "fl_sanitize",  # Sanitize SVG content
-        "e_sharpen",  # Sharpen images
     ]
+
+    if e_sharpen:
+        cloudinary_options.append("e_sharpen")
 
     # If the original image does not match the requested
     # ratio set crop and fill see

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="canonicalwebteam.image-template",
-    version="1.3.0",
+    version="1.3.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(

--- a/tests/test_image_template.py
+++ b/tests/test_image_template.py
@@ -86,6 +86,7 @@ class TestImageTemplate(unittest.TestCase):
             height="1080",
             loading="auto",
             fill=True,
+            e_sharpen=True,
             hi_def=False,
         )
         # Check e_sharpen is present


### PR DESCRIPTION
Make `image-template` `e_sharpen` setting optional. 

## QA
Some logos are be sharpened and look ugly.
Go to: https://ubuntu.com 
Scroll down to the Spotify logo (it's the easiest to see), it will look bad.
 
Go to: https://ubuntu-com-8409.demos.haus
Scroll down to the Spotify logo (it's the easiest to see), it will look nice.